### PR TITLE
Update helpers.py

### DIFF
--- a/luxpy/color/cri/utils/helpers.py
+++ b/luxpy/color/cri/utils/helpers.py
@@ -1438,7 +1438,7 @@ def spd_to_cri(St, cri_type = _CRI_TYPE_DEFAULT, out = 'Rf', wl = None, \
      xyzti,xyztw,
      xyzri,xyzrw,
      xyztw_cct,
-     cct,duv,St,Sr) = spd_to_jab_t_r(St, wl = wl, cri_type = cri_type, 
+     cct,duv,St,Sr) = spd_to_jab_t_r(St, wl = wl, cri_type = cri_type, ref_type=ref_type, 
                                           out = 'jabt,jabr,xyzti,xyztw,xyzri,xyzrw,xyztw_cct,cct,duv,St,Sr') 
 
     # E. calculate DEi, DEa:


### PR DESCRIPTION
Function "spd_to_cri()" is missing the argument "ref_type" when calling "spd_to_jab_t_r()" for passing the variable for further calculation with specific type of reference illuminant.