### PR TITLE
Update metrics_fast.py

### DIFF
--- a/luxpy/color/cri/iestm30/metrics_fast.py
+++ b/luxpy/color/cri/iestm30/metrics_fast.py
@@ -51,7 +51,7 @@ def _cri_ref_i(cct, wl3 = _WL, ref_type = 'iestm30', mix_range = [4000,5000],
 
     if (cct < mix_range[0]) | (ref_type == 'BB'):
         return blackbody(cct, wl3, n = n)
-    elif (cct > mix_range[0]) | (ref_type == 'DL'):
+    elif (cct > mix_range[1]) | (ref_type == 'DL'):
         return daylightphase(cct,wl3,force_daylight_below4000K = force_daylight_below4000K, cieobs = cieobs, daylight_locus = daylight_locus)
     else:
         SrBB = blackbody(cct, wl3, n = n)


### PR DESCRIPTION
Hey, thanks for the toolbox, it's a major contribution for my research! I found some deviations in calculating TM-30 metrics while using the metrics_fast methods in the mixed reference area from 4000 to 5000 K. The problem seems to be that the index for mixed_range  in line 54 should be the upper bound [1] but is set to the lower one [0]. So as a result, it is either BB or DL but never the mix of both. Best regards!