### PR TITLE
Update cqs.py - CCT factor GA in v7.5.

### DIFF
--- a/luxpy/color/cri/indices/cqs.py
+++ b/luxpy/color/cri/indices/cqs.py
@@ -120,7 +120,8 @@ def  spd_to_cqs(SPD, version = 'v9.0', out = 'Qa',wl = None):
     Qfi = np.zeros((labti.shape[0],labti.shape[1]))
     
     if version == 'v7.5':
-        GA = (9.2672*(1.0e-11))*cct**3.0  - (8.3959*(1.0e-7))*cct**2.0 + 0.00255*cct - 1.612 
+        GA = (9.2672*(1.0e-11))*cct**3.0  - (8.3959*(1.0e-7))*cct**2.0 + 0.00255*cct - 1.612
+        GA = np.where(cct < 3500, GA, 1) # It only needs to be calculated for CCTs of <3500 K.
     elif version == 'v9.0':
         GA = np.ones(cct.shape)
     else:


### PR DESCRIPTION
The CCT factor M_CCT (or GA here) only needs to be calculated for CCTs of <3500 K. For larger CCTs it is set to a constant of 1. Calculating it with the missing differentiation leads to unrealistic high metrics scores for Q_f, Q_a and Q_p in v7.5 when computing them for SPDs with CCTs >3500K. See DOI: 10.1117/1.3360335